### PR TITLE
Package new version with python3 and company_name update

### DIFF
--- a/SOURCES/branding-xcp-ng-8.3.0.tar.gz
+++ b/SOURCES/branding-xcp-ng-8.3.0.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a114d5dd12fd3b49cc9b8804c92d8db6bd8267423af03fa7d9aa467246c9fbb4
-size 106648
+oid sha256:9afbc10af289b88f876d36eb7ba433bbba6bfb42a67202b880e57f04c3b3b793
+size 106671

--- a/SPECS/branding-xcp-ng.spec
+++ b/SPECS/branding-xcp-ng.spec
@@ -1,12 +1,16 @@
 Name:           branding-xcp-ng
 Version:        8.3.0
-Release:        1
+Release:        2.73c8834
 Summary:        XCP-ng branding
 License:        ISC
 URL:            https://github.com/xcp-ng/branding-xcp-ng
 Source0:        https://github.com/xcp-ng/branding-xcp-ng/archive/v%{version}/branding-xcp-ng-%{version}.tar.gz
 BuildArch:      noarch
-Requires:       python
+Requires:       python3
+
+BuildRequires:  python3-devel
+# Make brp-python-bytecompile use python3
+%define __python /usr/bin/python3
 
 %description
 This package contains branding information for XCP-ng.
@@ -29,10 +33,14 @@ This package contains branding information for XCP-ng.
 %{_usrsrc}/branding/branding-compile.py
 %{_usrsrc}/branding/EULA
 %{_usrsrc}/branding/LICENSES
-%exclude %{_usrsrc}/branding/*.pyc
-%exclude %{_usrsrc}/branding/*.pyo
+%{_usrsrc}/branding/__pycache__
 
 %changelog
+* Thu Feb 02 2023 Yann Dirson <yann.dirson@vates.fr> - 8.3.0-2.73c8834
+- Switch to python3
+- COMPANY_NAME update to "Vates, XenServer and others"
+- COPYRIGHT_YEARS up to 2023
+
 * Thu Sep 01 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-1
 - Update for XCP-ng 8.3.0
 


### PR DESCRIPTION
Does not work yet: for some reason I don't see, some python2 macros are forced upon us, and prevent the use of python3 constructs:

```
+ cd branding-xcp-ng-8.3.0
+ /usr/bin/install -D -m 0644 branding/branding /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/branding
+ /usr/bin/install -D -m 0755 branding/brand-directory.py /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/brand-directory.py
+ /usr/bin/install -D -m 0755 branding/branding-compile.py /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/branding-compile.py
+ /usr/bin/install -D -m 0644 branding/EULA /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/EULA
+ /usr/bin/install -D -m 0644 branding/LICENSES /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/LICENSES
+ /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 /data/src/rpms/branding-xcp-ng/BUILD/branding-xcp-ng-8.3.0
/usr/lib/rpm/sepdebugcrcfix: Updated 0 CRC32s, 0 CRC32s did match.
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/redhat/brp-compress
+ /usr/lib/rpm/redhat/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
Compiling /data/src/rpms/branding-xcp-ng/BUILDROOT/branding-xcp-ng-8.3.0-1+python3.x86_64/usr/src/branding/brand-directory.py ...
  File "/usr/src/branding/brand-directory.py", line 14
    search = f"@{key}@"
                      ^
SyntaxError: invalid syntax
```
