### PR TITLE
New release 8.99.0

### DIFF
--- a/SOURCES/branding-xcp-ng-8.3.0.tar.gz
+++ b/SOURCES/branding-xcp-ng-8.3.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e99da650025c6ba8f2666bda434da36f1ee145dacc19a30aabcb6ce05ea28b41
-size 106642

--- a/SOURCES/branding-xcp-ng-8.99.0.tar.gz
+++ b/SOURCES/branding-xcp-ng-8.99.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3580f3b084ec3e45447e2f8efbc93e80a35b5b22743f18ce30f283c4513ef657
+size 106653

--- a/SPECS/branding-xcp-ng.spec
+++ b/SPECS/branding-xcp-ng.spec
@@ -1,7 +1,7 @@
 Name:           branding-xcp-ng
-Version:        8.3.0
+Version:        8.99.0
 # When increasing the first number, also update the hash if needed
-Release:        5.74d9cc1
+Release:        1.219ab5b
 Summary:        XCP-ng branding
 License:        ISC
 URL:            https://github.com/xcp-ng/branding-xcp-ng
@@ -39,9 +39,12 @@ This package contains branding information for XCP-ng.
 %{_usrsrc}/branding/branding-compile.py
 %{_usrsrc}/branding/EULA
 %{_usrsrc}/branding/LICENSES
-%{_usrsrc}/branding/__pycache__
 
 %changelog
+* Thu Mar 12 2026 Yann Dirson <yann.dirson@vates.tech> - 8.99.0-1.219ab5b
+- Official 8.99.0 release to prepare for XCP-ng v9
+- Don't ship __pycache__ any more
+
 * Wed Apr 09 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-5.74d9cc1
 - COPYRIGHT_YEARS up to 2025
 - Improved EULA text (formatting, wording, URLs)


### PR DESCRIPTION
This is a first branding-xcp-ng pre-release for v9, hopefully the only one we'll need, for xcp-ng-release package with the same structure as the 8.3 one.