### PR TITLE
Update copyright year to 2026

### DIFF
--- a/SOURCES/branding-xcp-ng-8.3.0.tar.gz
+++ b/SOURCES/branding-xcp-ng-8.3.0.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e99da650025c6ba8f2666bda434da36f1ee145dacc19a30aabcb6ce05ea28b41
-size 106642
+oid sha256:b096d72762eb028c4d2a97669dd17e45eb5de77845d9052af09359554aa7aa06
+size 106679

--- a/SPECS/branding-xcp-ng.spec
+++ b/SPECS/branding-xcp-ng.spec
@@ -1,14 +1,14 @@
 Name:           branding-xcp-ng
 Version:        8.3.0
 # When increasing the first number, also update the hash if needed
-Release:        5.74d9cc1
+Release:        6.84e001f
 Summary:        XCP-ng branding
 License:        ISC
 URL:            https://github.com/xcp-ng/branding-xcp-ng
 
 # As we don't tag for each change, because we want the release number to remain fixed for a given XCP-ng release,
 # archives are exported this way from the source repository:
-# export VER=8.3.0; git archive --format tgz master . --prefix branding-xcp-ng-$VER/ -o /path/to/SOURCES/branding-xcp-ng-$VER.tar.gz
+# export VER=8.3.0; git archive --format tgz 8.3 . --prefix branding-xcp-ng-$VER/ -o /path/to/SOURCES/branding-xcp-ng-$VER.tar.gz
 # Document the git hash of the commit corresponding to the tarball in the Release tag. Example: 2.d5ffe4d.
 Source0:        https://github.com/xcp-ng/branding-xcp-ng/archive/v%{version}/branding-xcp-ng-%{version}.tar.gz
 BuildArch:      noarch
@@ -42,6 +42,9 @@ This package contains branding information for XCP-ng.
 %{_usrsrc}/branding/__pycache__
 
 %changelog
+* Tue Jul 07 2026 Yann Dirson <yann.dirson@vates.tech> - 8.3.0-6.84e001f
+- COPYRIGHT_YEARS up to 2026
+
 * Wed Apr 09 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3.0-5.74d9cc1
 - COPYRIGHT_YEARS up to 2025
 - Improved EULA text (formatting, wording, URLs)


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3526

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

next ISO

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

none

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

(after rebuild of the proper packages) check the change is propagated to
- installer
- xsconsole

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

none

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
